### PR TITLE
Allow forked PR builds

### DIFF
--- a/src/ServarrAPI/Release/Azure/AzureReleaseSource.cs
+++ b/src/ServarrAPI/Release/Azure/AzureReleaseSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -110,10 +110,12 @@ namespace ServarrAPI.Release.Azure
 
                     if (pr.Head.Repository.Fork)
                     {
-                        continue;
+                        branch = string.Format("pr{0}", pr.Number);
                     }
-
-                    branch = pr.Head.Ref;
+                    else
+                    {
+                        branch = pr.Head.Ref;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This changes adds forked PR builds to the update server allowing testing easily from within Arr... 

Currently naming is `pr4611` though we can change that to be author-branch or something if that makes more sense. The downside of this is if someone pushes a malicious change. Should we gate this somehow? User whitelist or something in settings?