### PR TITLE
New: Version gating for controlling updates

### DIFF
--- a/src/ServarrAPI/Config.cs
+++ b/src/ServarrAPI/Config.cs
@@ -1,10 +1,19 @@
+using System.Collections.Generic;
+using ServarrAPI.Model;
+
 namespace ServarrAPI
 {
     public class Config
     {
+        public Config()
+        {
+            VersionGates = new List<VersionGate>();
+        }
+
         public string DataDirectory { get; set; }
         public string ApiKey { get; set; }
         public string Project { get; set; }
         public bool LogSql { get; set; }
+        public List<VersionGate> VersionGates { get; set; }
     }
 }

--- a/src/ServarrAPI/Controllers/UpdateController.cs
+++ b/src/ServarrAPI/Controllers/UpdateController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,13 +23,14 @@ namespace ServarrAPI.Controllers.Update
         [Route("{branch}/changes")]
         [HttpGet]
         public async Task<object> GetChanges([FromRoute(Name = "branch")] string updateBranch,
+                                             [FromQuery(Name = "version")] string urlVersion,
                                              [FromQuery(Name = "os")] OperatingSystem operatingSystem,
                                              [FromQuery(Name = "runtime")] Runtime runtime = Runtime.DotNet,
                                              [FromQuery(Name = "arch")] Architecture arch = Architecture.X64)
         {
             Response.Headers[HeaderNames.CacheControl] = GetCacheControlHeader(DateTime.UtcNow.AddDays(30));
 
-            var updateFiles = await _updateFileService.Find(updateBranch, operatingSystem, runtime, arch, 5);
+            var updateFiles = await _updateFileService.Find(updateBranch, operatingSystem, runtime, arch, 5, urlVersion);
 
             var response = new List<UpdatePackage>();
 
@@ -81,7 +82,8 @@ namespace ServarrAPI.Controllers.Update
                 };
             }
 
-            var files = await _updateFileService.Find(updateBranch, operatingSystem, runtime, arch, 5);
+            var files = await _updateFileService.Find(updateBranch, operatingSystem, runtime, arch, 1, urlVersion);
+
             var updateFile = files.FirstOrDefault();
 
             if (updateFile == null)

--- a/src/ServarrAPI/Datastore/Migration/002_break_up_version.cs
+++ b/src/ServarrAPI/Datastore/Migration/002_break_up_version.cs
@@ -1,0 +1,28 @@
+using FluentMigrator;
+using Microsoft.Extensions.Logging;
+using ServarrAPI.Datastore.Migration.Framework;
+
+namespace ServarrAPI.Datastore.Migration
+{
+    [Migration(2)]
+    public class BreakUpVersion : NzbDroneMigrationBase
+    {
+        public BreakUpVersion(ILogger<InitialSetup> logger)
+            : base(logger)
+        {
+        }
+
+        protected override void MainDbUpgrade()
+        {
+            Create.Column("intversion").OnTable("update").AsInt64().NotNullable().WithDefaultValue(0).Indexed();
+
+            // Create a sortable integer for version that can easily be compared against a max version,
+            // supports any major, minor to 99, patch to 99, builds up to 999,999.
+            Execute.Sql("UPDATE update SET intversion = " +
+                "((string_to_array(version, '.')::int[])[1] * 10000000000) + " +
+                "((string_to_array(version, '.')::int[])[2] * 100000000) + " +
+                "((string_to_array(version, '.')::int[])[3] * 1000000) + " +
+                "((string_to_array(version, '.')::int[])[4])");
+        }
+    }
+}

--- a/src/ServarrAPI/Extensions/VersionExtensions.cs
+++ b/src/ServarrAPI/Extensions/VersionExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ServarrAPI.Extensions
+{
+    public static class VersionExtensions
+    {
+        public static long ToIntVersion(this Version version)
+        {
+            return (version.Major * 10000000000) + (version.Minor * 100000000) + (version.Build * 1000000) + version.Revision;
+        }
+    }
+}

--- a/src/ServarrAPI/Model/UpdateEntity.cs
+++ b/src/ServarrAPI/Model/UpdateEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ServarrAPI.Datastore;
 
@@ -7,6 +7,7 @@ namespace ServarrAPI.Model
     public class UpdateEntity : ModelBase
     {
         public string Version { get; set; }
+        public long IntVersion { get; set; }
         public DateTime ReleaseDate { get; set; }
         public List<string> New { get; set; } = new List<string>();
         public List<string> Fixed { get; set; } = new List<string>();

--- a/src/ServarrAPI/Model/VersionGate.cs
+++ b/src/ServarrAPI/Model/VersionGate.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ServarrAPI.Model
+{
+    public class VersionGate
+    {
+        public Version MaxVersion { get; set; }
+        public Version MaxUpgradeVersion { get; set; }
+    }
+}

--- a/src/ServarrAPI/Release/Azure/AzureReleaseSource.cs
+++ b/src/ServarrAPI/Release/Azure/AzureReleaseSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -161,10 +161,13 @@ namespace ServarrAPI.Release.Azure
                     continue;
                 }
 
+                var version = Version.Parse(build.BuildNumber);
+
                 // Create update object
                 updateEntity = new UpdateEntity
                 {
                     Version = build.BuildNumber,
+                    IntVersion = version.ToIntVersion(),
                     ReleaseDate = build.StartTime.Value,
                     Branch = branch
                 };

--- a/src/ServarrAPI/Release/Github/GithubReleaseSource.cs
+++ b/src/ServarrAPI/Release/Github/GithubReleaseSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Octokit;
+using ServarrAPI.Extensions;
 using ServarrAPI.Model;
 using ServarrAPI.Util;
 
@@ -86,10 +87,13 @@ namespace ServarrAPI.Release.Github
                 return isNewRelease;
             }
 
+            var parsedVersion = Version.Parse(version);
+
             // Create update object
             updateEntity = new UpdateEntity
             {
                 Version = version,
+                IntVersion = parsedVersion.ToIntVersion(),
                 ReleaseDate = release.PublishedAt.Value.UtcDateTime,
                 Branch = branch
             };

--- a/src/ServarrAPI/appsettings.json
+++ b/src/ServarrAPI/appsettings.json
@@ -5,8 +5,10 @@
   "Update": {
     "DataDirectory": "",
     "ApiKey": "test",
-    "Project":  "Lidarr",
-    "LogSql": false
+    "Project": "Lidarr",
+    "LogSql": false,
+    "VersionGates": [
+    ]
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
**DB Migration**
Yes - Migration 2 (IntVersion Column)

**Description**
This adds support for gating updates via the following syntax int he appsettings.json. Gates are a list of pairs and get user in the `branch` and `branch/changes` endpoints to determine the maxVerison that a user can recieve back based on the version passed by Radarr/Lidarr/Readarr. Gates needs to be setup differently for each Arr

```
  "Update": {
    "VersionGates": [
      {
        "MaxVersion": "0.2.0.1430",
        "MaxUpgradeVersion": "0.2.0.1480"
      }
    ]
  },
```

~~One issue currently is that we call the repo and set a hard count to the number of updates we want to get back. This is problematic for gating as the only update a user can get may not be in those 5. Thus we need a better way to grab all the version in the db then compare with gates and return the best update. This may slow the response unless we have a way to compare the maxVersion string to db version via `<=` in SQL~~

Additionally this can happen on the original start of the server since we are only fetching last 10 builds from Azure. Users can get stranded if they are on a version that requires an update step to a new version that is not in those 10. We should likely limit gates to GitHub builds where we can as they are persistent

TODO:
- [x] Move MaxVersion compare to the repo or service

EDIT:
All Issues should be resolved by adding BIGINT intversion column to DB to store the update version as padded integer (03 00 00 001234) = 30000001234. This allows direct compare to a "MaxVersion" in the query as well as easy sort by version.