### PR TITLE
Default Windows to x86 when no arch passed

### DIFF
--- a/src/ServarrAPI/Model/UpdateFileRepository.cs
+++ b/src/ServarrAPI/Model/UpdateFileRepository.cs
@@ -41,6 +41,10 @@ namespace ServarrAPI.Model
             {
                 builder.Where<UpdateFileEntity>(f => f.Runtime == runtime && f.Architecture == arch);
             }
+            else if (os == OperatingSystem.Windows)
+            {
+                builder.Where<UpdateFileEntity>(f => f.Architecture == arch);
+            }
 
             if (maxVersion != null)
             {

--- a/src/ServarrAPI/Model/UpdateFileService.cs
+++ b/src/ServarrAPI/Model/UpdateFileService.cs
@@ -38,7 +38,7 @@ namespace ServarrAPI.Model
         public Task<UpdateFileEntity> Find(string version, string branch, OperatingSystem os, Runtime runtime, Architecture arch)
         {
             runtime = SetRuntime(runtime);
-            arch = SetArch(runtime, arch);
+            arch = SetArch(runtime, arch, os);
             os = SetOs(runtime, os);
 
             return _repo.Find(version, branch, os, runtime, arch);
@@ -47,7 +47,7 @@ namespace ServarrAPI.Model
         public Task<List<UpdateFileEntity>> Find(string branch, OperatingSystem os, Runtime runtime, Architecture arch, int count, string installedVersion = null)
         {
             runtime = SetRuntime(runtime);
-            arch = SetArch(runtime, arch);
+            arch = SetArch(runtime, arch, os);
             os = SetOs(runtime, os);
             var maxVersion = GetMaxVersion(installedVersion);
 
@@ -65,11 +65,16 @@ namespace ServarrAPI.Model
             return runtime;
         }
 
-        private Architecture SetArch(Runtime runtime, Architecture arch)
+        private Architecture SetArch(Runtime runtime, Architecture arch, OperatingSystem os)
         {
-            // If runtime is DotNet then default arch to x64
+            // If runtime is DotNet then default arch to x64 (or x86 for Windows given we build both)
             if (runtime == Runtime.DotNet)
             {
+                if (os == OperatingSystem.Windows)
+                {
+                    return Architecture.X86;
+                }
+
                 return Architecture.X64;
             }
 

--- a/src/ServarrAPI/Util/Parser.cs
+++ b/src/ServarrAPI/Util/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using ServarrAPI.Model;
@@ -8,9 +8,9 @@ namespace ServarrAPI.Util
 {
     public static class Parser
     {
-        public static readonly Regex NetCoreAsset = new Regex(@"(bsd|linux|linux-musl|osx|windows)-core-(x64|arm|arm64)", RegexOptions.Compiled);
+        public static readonly Regex NetCoreAsset = new Regex(@"(bsd|linux|linux-musl|osx|windows)-core-(x86|x64|arm|arm64)", RegexOptions.Compiled);
 
-        public static readonly Regex WindowsAsset = new Regex(@"windows(-core-(x64|arm|arm64))?\.zip$", RegexOptions.Compiled);
+        public static readonly Regex WindowsAsset = new Regex(@"windows(-core-(x86|x64|arm|arm64))?\.zip$", RegexOptions.Compiled);
 
         public static readonly Regex LinuxAsset = new Regex(@"linux(-core-(x64|arm|arm64))?\.tar.gz$", RegexOptions.Compiled);
 
@@ -20,7 +20,7 @@ namespace ServarrAPI.Util
 
         public static readonly Regex BsdAsset = new Regex(@"bsd(-core-(x64|arm|arm64))?\.tar.gz$", RegexOptions.Compiled);
 
-        public static readonly Regex ArchRegex = new Regex(@"core-(?<arch>x64|arm|arm64)\.", RegexOptions.Compiled);
+        public static readonly Regex ArchRegex = new Regex(@"core-(?<arch>x86|x64|arm|arm64)\.", RegexOptions.Compiled);
 
         public static OperatingSystem? ParseOS(string file)
         {


### PR DESCRIPTION
Now that we build x86 windows, default v0.2 instances to x86 so that x86 machines are not broken. Arr will grab x64 on the next update if the machine is x64 arch.